### PR TITLE
increase compat bound for StaticArrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,5 +12,5 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+StaticArrays = "~0.12, 1.0"
 julia = "~1"
-StaticArrays = "~0.12"


### PR DESCRIPTION
Thanks for this useful Package!

It would be create if this could be merged and to have a new release. Currently `AdaptiveMCMC.jl` holds back `StaticArray.jl`, which has released its 1.0 recently.

