### PR TITLE
Alteration to Restart MCMC with Stored Scaling and RNG State

### DIFF
--- a/src/adaptive_rwm.jl
+++ b/src/adaptive_rwm.jl
@@ -138,6 +138,8 @@ including adaptive parallel tempering.
 - `b::Int`: Number of burn-in iterations (before starting to collect samples); default `n/5`
 - `thin::Int`: Thinning factor; only every `thin`:th sample is stored; default `1`
 - `fulladapt::Bool`: Whether to adapt after burn-in; default `true`
+- `Sp`: Saved adaptive state from output to restart MCMC; default `nothing`
+- `Rp`: Saved rng state from output to restart MCMC; default `nothing`
 - `rng::AbstractRNG`: Random number generator; default `Random.GLOBAL_RNG`
 - `q::Function`: Zero-mean symmetric proposal generator (with arguments `x` and `rng`);
    default `q=randn!(x, rng)`
@@ -167,9 +169,9 @@ using MCMCChains, StatsPlots # Assuming MCMCChains & StatsPlots are installed...
 c = Chains(o.X[1]', start=o.params.b, thin=o.params.thin); plot(c)
 ```
 """
-function adaptive_rwm(x0::T, log_p::Function, n::Int;
+function adaptive_rwm_jh(x0::T, log_p::Function, n::Int;
     algorithm::Union{Symbol,Vector{<:AdaptState}}=:ram,
-    thin::Int=1, b::Int=Int(floor(n/5)), fulladapt::Bool=true,
+    thin::Int=1, b::Int=Int(floor(n/5)), fulladapt::Bool=true, Sp=nothing, Rp=nothing,
     q::Function=randn!, L::Int=1, log_pr::Function = (x->zero(FT)),
     all_levels::Bool=false, acc_sw::FT = FT(0.234), swaps::Symbol = :single,
     rng::AbstractRNG=Random.GLOBAL_RNG) where {FT <: AbstractFloat,
@@ -185,6 +187,12 @@ function adaptive_rwm(x0::T, log_p::Function, n::Int;
     X, D, R, S, P = init_arwm(x0, algorithm, rng, q, L,
                               all_levels, nX, log_p, log_pr)
 
+    if Sp!=nothing
+        S=Sp
+    end
+    if Rp!=nothing
+        R=Rp
+    end
 
     adaptive_rwm_(X, D, R, S, P, args, params, x0, log_p, n,
         thin, b, fulladapt,

--- a/src/adaptive_rwm.jl
+++ b/src/adaptive_rwm.jl
@@ -169,7 +169,7 @@ using MCMCChains, StatsPlots # Assuming MCMCChains & StatsPlots are installed...
 c = Chains(o.X[1]', start=o.params.b, thin=o.params.thin); plot(c)
 ```
 """
-function adaptive_rwm_jh(x0::T, log_p::Function, n::Int;
+function adaptive_rwm(x0::T, log_p::Function, n::Int;
     algorithm::Union{Symbol,Vector{<:AdaptState}}=:ram,
     thin::Int=1, b::Int=Int(floor(n/5)), fulladapt::Bool=true, Sp=nothing, Rp=nothing,
     q::Function=randn!, L::Int=1, log_pr::Function = (x->zero(FT)),


### PR DESCRIPTION
Hello,
I have found your code super useful.  I run it in a queue so I like to be able to recover from where I left off and to save the chain as it goes, so I have added two new parameters to the adaptive_rwm : Sp and Rp which contain the scaling state and RNG state as returned by adaptive_rwm.  Of course this works much better than restarting the chain with the last sample because the scaling info is retained.
Jeremy